### PR TITLE
Fix to Ignore non-function hook values

### DIFF
--- a/dump.lua
+++ b/dump.lua
@@ -243,7 +243,7 @@ local function dump_state(file, options)
 			-- TODO param names
 		elseif t == "thread" then
 			local hookf, hookmask, hookcount = debug.gethook(obj);
-			if hookf then
+			if type(hookf) == "function" then
 				edge(
 					id, "hook",
 					get_id(hookf),


### PR DESCRIPTION
debug.gethook() can sometimes return the string "external hook", if the hook is a C function set via the Lua C API. Ignoring it should be safe from a traversal perspective, as such a function is not a GC object and wouldn't hold references.

Not ignoring it causes an assertion failure in push() due to the type being simple (string) rather than complex (function).

https://www.lua.org/source/5.2/ldblib.c.html#db_gethook