### PR TITLE
Use %p (pointer) format as basis for object ids

### DIFF
--- a/dump.lua
+++ b/dump.lua
@@ -113,6 +113,34 @@ local function dump_state(file, options)
 		processed[obj] = 0;
 	end
 
+	if pcall(string.format, "%p", "") then
+		local format = string.format;
+		local function new_id(obj)
+			local t = type(obj);
+			if t == "function" or t == "string" or t == "table" or t == "userdata" or t == "thread" then
+				return format("%s:%p", t, obj);
+			elseif t == "number" or t == "boolean" or t == "nil" then
+				return format("%s:%q", t, obj);
+			else
+				error("don't know how to reference a "..t)
+			end
+		end
+
+		function skip(obj)
+			processed[ new_id(obj) ] = 0;
+		end
+
+		function get_id(obj) --> string | 0
+			if nil == obj then return 0; end
+			local id = new_id(obj);
+			if not processed[id] then
+				push(obj);
+				processed[id] = 0;
+			end
+			return id;
+		end
+	end
+
 	local escapes = {
 		["\""] = "\\\"", ["\\"] = "\\\\", ["\b"] = "\\b",
 		["\f"] = "\\f", ["\n"] = "\\n", ["\r"] = "\\r", ["\t"] = "\\t"};

--- a/dump.lua
+++ b/dump.lua
@@ -109,6 +109,9 @@ local function dump_state(file, options)
 		processed[obj] = processed_counter;
 		return processed_counter;
 	end
+	local function skip(obj)
+		processed[obj] = 0;
+	end
 
 	local escapes = {
 		["\""] = "\\\"", ["\\"] = "\\\\", ["\b"] = "\\b",
@@ -159,8 +162,8 @@ local function dump_state(file, options)
 		thread_mt = debug.getmetatable(debug.getregistry()[1]);
 	};
 
-	processed[dump_state] = 0;
-	processed[root] = 0;
+	skip(dump_state);
+	skip(root);
 
 	push(root);
 


### PR DESCRIPTION
This only works in Lua 5.4 which adds `string.format("%p", object)`.

Pointers are more stable and will have the same value across
invocations, unlike the counter method which may assign different ids to
the same object on each run.

Having stable IDs makes it easier to compare dumps from different times.

